### PR TITLE
Address certificate issues in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,13 @@ $ curl -L -H "Authorization: $TOKEN" https://hostname/api/v1/networkDevices | jq
 }
 $ unset TOKEN
 ```
+
+## Certificate Issues
+
+Curl checks the certificates of your server. If the certificate is not trusted then the curl operations will fail. Here are some workarounds. See [SSL Certification Verification](https://curl.haxx.se/docs/sslcerts.html) for more information.
+
+1. Manually add the certificate to your local keystore and mark it as trusted
+2. Export the certificate in pem format and pass it on the command line.
+3. Use the `--insecure` option. **Note:** this is not recommended for production environments.
+
+There are examples of how to use the last 2 options in the READMEs of the subfolders: [devices](./devices/README.md#certificate-issues), [test-drive](./test-drive/README.md#certificate-issues).

--- a/devices/README.md
+++ b/devices/README.md
@@ -63,3 +63,19 @@ Here is a description of each file
 
 If something goes wrong these files will contain the headers and response bodies to help you
 debug.
+
+## Certificate Issues
+
+Curl checks the certificates of your server. If the certificate is not trusted then the curl operations will fail. Here are some workarounds. See [SSL Certification Verification](https://curl.haxx.se/docs/sslcerts.html) for more information.
+
+1. Manually add the certificate to your local keystore and mark it as trusted
+2. Export the certificate in pem format and pass it on the command line. The following example assumes you have done this and named the file `server-certificate.pem`
+
+    ```shell
+    ./devices --ca-cert server-certificate.pem
+    ```
+3. Use the `--insecure` option. **Note:** this is not recommended for production environments.
+
+    ```shell
+    ./devices --insecure
+    ```

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -15,7 +15,7 @@ The script requires a username, password and hostname.
 You will be prompted for these every time you run the script.
 
 ```shell
-$ ./get-all
+$ ./test-drive
 username: johnsmith
 password:
 host: adx-server

--- a/test-drive/test-drive
+++ b/test-drive/test-drive
@@ -36,9 +36,9 @@ curl \
 
 
 # Extract the access_token out of the login-result file and store it separtely
-jq -r ".access_token" $OUTPUT_DIR/login-result.json > $OUTPUT_DIR/access_token.txt
+jq -r ".accessToken" $OUTPUT_DIR/login-result.json > $OUTPUT_DIR/access_token.txt
 
-token_header="Authorization: Bearer $(cat $OUTPUT_DIR/access_token.txt)"
+token_header="Authorization: Bearer $(< $OUTPUT_DIR/access_token.txt)"
 
 echo
 echo Getting first page of network devices


### PR DESCRIPTION
This pull request adds sections outlining what to do if you have certificate issues. It also fixes an issue in test-drive where the wrong filter was used to get the accessToken.